### PR TITLE
turbo_deviseコントローラーの作成

### DIFF
--- a/app/controllers/turbo_devise_controller.rb
+++ b/app/controllers/turbo_devise_controller.rb
@@ -1,0 +1,18 @@
+class TurboDeviseController < ApplicationController
+    class Responder < ActionController::Responder
+      def to_turbo_stream
+        controller.render(options.merge(formats: :html))
+      rescue ActionView::MissingTemplate => error
+        if get?
+          raise error
+        elsif has_errors? && default_action
+          render rendering_options.merge(formats: :html, status: :unprocessable_entity)
+        else
+          redirect_to navigation_location
+        end
+      end
+    end
+
+    self.responder = Responder
+    respond_to :html, :turbo_stream
+end


### PR DESCRIPTION
TurboとDeviseを統合するためのTurboDeviseコントローラーを作成。
DeviseのアクションをTurboを介して非同期的に処理する内容を追記。